### PR TITLE
[RFR] remove sort selector from publicationSearch

### DIFF
--- a/lib/containers/createSearchResultContainer.js
+++ b/lib/containers/createSearchResultContainer.js
@@ -22,7 +22,7 @@ const PaginationContainers = {
 
 const SelectorContainers = {
     article: createSortSelectorContainer('article'),
-    publication: createSortSelectorContainer('publication')
+    publication: null
 };
 
 const ResultsPerPageSelectorContainers = {

--- a/test/e2e/test/publicationSearch.js
+++ b/test/e2e/test/publicationSearch.js
@@ -34,7 +34,6 @@ describe('publicationSearch', function() {
         .assert.containsText('.a2z-search .second.letters', 'BA BB BC BD BE BF BG BH BI BJ BK BL BM BN BO BP BQ BR BS BT BU BV BW BX BY BZ')
         .assert.value('.search-input .term input', 'B*')
         .assert.containsText('.field.select-button', 'Titre')
-        .assert.containsText('.sort.select-button', 'pertinence')
         .waitForElementVisible('.search-result', 1000)
         .assert.elementCount('.record', 20);
 


### PR DESCRIPTION
pertinence was already the default