### PR TITLE
[RFR] display connection button inline if no #ebsco_widget_connection of if fullscreen

### DIFF
--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -6,13 +6,11 @@ import Error from '../containers/Error';
 import Authentication from '../containers/Authentication';
 import Profile from '../containers/Profile';
 import Header from '../containers/Header';
-import Connection from '../containers/Connection';
 
 const App = ({ children }) => {
     return (
         <div className="ebsco-widget">
             <Header />
-            <Connection />
             <Authentication />
             <Profile />
             <Error />

--- a/lib/components/BibNavbar.js
+++ b/lib/components/BibNavbar.js
@@ -6,6 +6,7 @@ import LanguageSelector from '../containers/LanguageSelector';
 import translate from '../higherOrderComponents/translate';
 import NavItem from './NavItem';
 import { BibButton } from './BibButton';
+import Connection from '../containers/Connection';
 
 const BibNavbar = ({ location, fullScreen, text, navigate, setFullScreen }) => {
     return (
@@ -38,6 +39,7 @@ const BibNavbar = ({ location, fullScreen, text, navigate, setFullScreen }) => {
                 </NavItem>
                 <Navbar.Form pullRight>
                     <LanguageSelector />
+                    <Connection fullScreen={fullScreen} />
                     {fullScreen ? (
                         <BibButton
                             bsStyle="link"

--- a/lib/components/Connection.js
+++ b/lib/components/Connection.js
@@ -4,14 +4,10 @@ import PropTypes from 'prop-types';
 
 import { BibButton } from './BibButton';
 
-const Connection = ({ logged, logout, showLogin, text }) => {
+const Connection = ({ logged, logout, showLogin, fullScreen, text }) => {
     const connectionRoot = document.getElementById('ebsco_widget_connection');
 
-    if (!connectionRoot) {
-        return null;
-    }
-
-    return ReactDOM.createPortal(
+    const connectionElement = (
         <div className="connection">
             {logged ? (
                 <BibButton
@@ -28,9 +24,12 @@ const Connection = ({ logged, logout, showLogin, text }) => {
                     label={text.connect}
                 />
             )}
-        </div>,
-        connectionRoot,
+        </div>
     );
+
+    return !connectionRoot || fullScreen
+        ? connectionElement
+        : ReactDOM.createPortal(connectionElement, connectionRoot);
 };
 
 Connection.propTypes = {

--- a/lib/index.html
+++ b/lib/index.html
@@ -6,7 +6,6 @@
 
   </head>
   <body>
-    <div id="ebsco_widget_connection" style="position: absolute; top: 0px; right: 20px; overflow: auto;"></div>
     <div id="ebsco_widget_header" style="position: absolute; top: 0px; left: 20px; overflow: auto;"></div>
     <div id="ebsco_widget" style="border:solid #BBBBBB 1px; position: absolute; top: 120px; bottom: 100px; left: 200px; right: 200px; overflow: auto;"></div>
     <script src="node_modules/babel-polyfill/dist/polyfill.js"></script>

--- a/lib/sass/_Header.scss
+++ b/lib/sass/_Header.scss
@@ -21,10 +21,12 @@
 }
 
 .connection {
+    display: inline;
     .btn {
         .text{
             text-transform: uppercase;
             font-weight: bold;
+            color: #337ab7;
         }
     }
 }


### PR DESCRIPTION
https://trello.com/c/wNVnbH9E/117-025bibcnrs-d%C3%A9placer-lc%C3%B4ne-mon-profil-au-niveau-de-lutilisateur-et-connexion

- [x] allow to display connection inside the widget, instead of outside
- [x] (bonus) always display the connection inline when fullscreen