### PR TITLE
keep same input between article and publication

### DIFF
--- a/lib/components/Search.js
+++ b/lib/components/Search.js
@@ -19,7 +19,9 @@ export const Search = ({
                 <FetchButton
                     className="search-button"
                     disabled={!term}
-                    onClick={onSearch}
+                    onClick={() => {
+                        onSearch(sessionStorage.getItem('searchValue'));
+                    }}
                     status={status}
                     icon="search"
                     label={text.search}

--- a/lib/components/SearchInput.js
+++ b/lib/components/SearchInput.js
@@ -1,79 +1,103 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import { Button, FormControl, InputGroup } from 'react-bootstrap';
 import Icon from 'react-fa';
 
-const SearchInput = ({
-    label,
-    placeholder,
-    value,
-    suggestedValues,
-    buttonBefore,
-    onChange,
-    onSearch,
-    clearAutocomplete,
-    buttonAfter,
-}) => {
-    return (
-        <div className="search-input">
-            <InputGroup>
-                <InputGroup.Button className="before">
-                    {buttonBefore}
-                </InputGroup.Button>
-                <div className="term">
-                    <FormControl
-                        type="search"
-                        value={value}
-                        label={label}
-                        placeholder={placeholder}
-                        onChange={e => onChange(e.target.value)}
-                        onFocus={e => onChange(e.target.value)}
-                        onBlur={() => setTimeout(clearAutocomplete, 100)} // DIRTY: delay to be able to click on autocomplete item
-                        onKeyPress={event =>
-                            event.key === 'Enter' &&
-                            onSearch(event.target.value)
-                        }
-                    />
-                    {suggestedValues.length ? (
-                        <div className="autocompletion">
-                            {[''].concat(suggestedValues).map((val, index) => (
-                                <InputGroup.Button
-                                    className="suggestion"
-                                    key={index}
-                                >
-                                    <Button
-                                        bsStyle="link"
-                                        block
-                                        onMouseDown={() => {
-                                            onChange(`${value}${val}`);
-                                            setTimeout(onSearch, 100);
-                                        }}
-                                    >
-                                        <span className="suggested-term">
-                                            <strong>{value}</strong>
-                                            {val}
-                                        </span>
-                                    </Button>
-                                </InputGroup.Button>
-                            ))}
-                        </div>
-                    ) : (
-                        <span />
-                    )}
-                </div>
-                <InputGroup.Button
-                    className="search-clear"
-                    onClick={() => onChange('')}
-                >
-                    <Icon name="times-circle" />
-                </InputGroup.Button>
-                <InputGroup.Button className="after hidden">
-                    {buttonAfter}
-                </InputGroup.Button>
-            </InputGroup>
-        </div>
-    );
-};
+export class SearchInput extends Component {
+    state = {
+        value: sessionStorage.getItem('searchValue'),
+    };
+
+    render() {
+        const {
+            label,
+            placeholder,
+            suggestedValues,
+            buttonBefore,
+            onChange,
+            onSearch,
+            clearAutocomplete,
+            buttonAfter,
+        } = this.props;
+
+        return (
+            <div className="search-input">
+                <InputGroup>
+                    <InputGroup.Button className="before">
+                        {buttonBefore}
+                    </InputGroup.Button>
+                    <div className="term">
+                        <FormControl
+                            type="search"
+                            value={this.state.value}
+                            label={label}
+                            placeholder={placeholder}
+                            onChange={e => {
+                                this.setState({ value: e.target.value });
+                                onChange(e.target.value);
+                            }}
+                            onFocus={e => {
+                                this.setState({ value: e.target.value });
+                                onChange(e.target.value);
+                            }}
+                            onBlur={() => setTimeout(clearAutocomplete, 100)} // DIRTY: delay to be able to click on autocomplete item
+                            onKeyPress={event => {
+                                if (event.key === 'Enter') {
+                                    sessionStorage.setItem(
+                                        'searchValue',
+                                        event.target.value,
+                                    );
+                                    onSearch(event.target.value);
+                                }
+                            }}
+                        />
+                        {suggestedValues.length ? (
+                            <div className="autocompletion">
+                                {['']
+                                    .concat(suggestedValues)
+                                    .map((val, index) => (
+                                        <InputGroup.Button
+                                            className="suggestion"
+                                            key={index}
+                                        >
+                                            <Button
+                                                bsStyle="link"
+                                                block
+                                                onMouseDown={() => {
+                                                    onChange(
+                                                        `${this.state.value}${val}`,
+                                                    );
+                                                    setTimeout(onSearch, 100);
+                                                }}
+                                            >
+                                                <span className="suggested-term">
+                                                    <strong>
+                                                        {this.state.value}
+                                                    </strong>
+                                                    {val}
+                                                </span>
+                                            </Button>
+                                        </InputGroup.Button>
+                                    ))}
+                            </div>
+                        ) : (
+                            <span />
+                        )}
+                    </div>
+                    <InputGroup.Button
+                        className="search-clear"
+                        onClick={() => onChange('')}
+                    >
+                        <Icon name="times-circle" />
+                    </InputGroup.Button>
+                    <InputGroup.Button className="after hidden">
+                        {buttonAfter}
+                    </InputGroup.Button>
+                </InputGroup>
+            </div>
+        );
+    }
+}
 
 SearchInput.propTypes = {
     label: PropTypes.string,


### PR DESCRIPTION
La saisie de la requête lors du changement d'onglets est bien gardé. 
Cependant, lorsqu'on saisie une requête dans un onglet, la valeur apparait bien dans le second onglet mais est ignoré lors de la recherche.
j'utilise également des `sessionStorage` pour stocker l'infos, il doit exister une meilleur méthode en utilisant le `state` de react directement.